### PR TITLE
[HER-130] Use double for location

### DIFF
--- a/src/Business/Camera/Common/Models/MCamera.cs
+++ b/src/Business/Camera/Common/Models/MCamera.cs
@@ -4,8 +4,8 @@ namespace Business.Camera.Common.Models
     {
         public string Id { get; set; }
 
-        public string Longitude { get; set; }
+        public double Longitude { get; set; }
 
-        public string Latitude { get; set; }
+        public double Latitude { get; set; }
     }
 }

--- a/src/Business/Camera/Register/Models/MRegisterCamera.cs
+++ b/src/Business/Camera/Register/Models/MRegisterCamera.cs
@@ -4,8 +4,8 @@ namespace Business.Camera.Register.Models
     {
         public string Id { get; set; }
 
-        public string Longitude { get; set; }
+        public double Longitude { get; set; }
 
-        public string Latitude { get; set; }
+        public double Latitude { get; set; }
     }
 }

--- a/src/Data/Camera/Entities/ECamera.cs
+++ b/src/Data/Camera/Entities/ECamera.cs
@@ -8,9 +8,9 @@ namespace Data
         public string Id { get; set; }
 
         [Required]
-        public string Latitude { get; set; }
+        public double Latitude { get; set; }
 
         [Required]
-        public string Longitude { get; set; }
+        public double Longitude { get; set; }
     }
 }

--- a/src/Data/Camera/Filtering/SeedFilter.cs
+++ b/src/Data/Camera/Filtering/SeedFilter.cs
@@ -1,5 +1,6 @@
 namespace Data.Camera.Filtering
 {
+    using System;
     using System.Linq;
     using Business.Camera.Register.Models;
     using Microsoft.EntityFrameworkCore;
@@ -27,13 +28,9 @@ namespace Data.Camera.Filtering
                 : input.Where(item => EF.Functions.Like(item.Id, $"%{_camera.Id}%"));
 
         private IQueryable<ECamera> MatchLatitude(IQueryable<ECamera> input) =>
-            string.IsNullOrEmpty(_camera.Latitude)
-                ? input
-                : input.Where(item => EF.Functions.Like(item.Latitude, $"%{_camera.Latitude}%"));
+            input.Where(camera => Math.Abs(camera.Latitude - _camera.Latitude) < Math.Abs(camera.Latitude * 0.00001) && camera.Latitude.Equals(_camera.Latitude));
 
         private IQueryable<ECamera> MatchLongitude(IQueryable<ECamera> input) =>
-            string.IsNullOrEmpty(_camera.Longitude)
-                ? input
-                : input.Where(item => EF.Functions.Like(item.Longitude, $"%{_camera.Longitude}%"));
+            input.Where(camera => Math.Abs(camera.Longitude - _camera.Longitude) < Math.Abs(camera.Longitude * 0.00001) && camera.Longitude.Equals(_camera.Longitude));
     }
 }

--- a/src/Data/Migrations/20210803124014_AlterCamerasChangeFields.Designer.cs
+++ b/src/Data/Migrations/20210803124014_AlterCamerasChangeFields.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20210803124014_AlterCamerasChangeFields")]
+    partial class AlterCamerasChangeFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Data/Migrations/20210803124014_AlterCamerasChangeFields.cs
+++ b/src/Data/Migrations/20210803124014_AlterCamerasChangeFields.cs
@@ -1,0 +1,45 @@
+﻿namespace Data.Migrations
+{
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    public partial class AlterCamerasChangeFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "Longitude",
+                table: "Cameras",
+                type: "double",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "Latitude",
+                table: "Cameras",
+                type: "double",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Longitude",
+                table: "Cameras",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Latitude",
+                table: "Cameras",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double");
+        }
+    }
+}

--- a/src/Seeds/Data/cameras.json
+++ b/src/Seeds/Data/cameras.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "default",
-    "latitude": "53.27137",
-    "longitude": "-7.827415"
+    "latitude": 53.27137,
+    "longitude": -7.827415
   }
 ]

--- a/test/Data.UnitTests/Camera/CameraFactoryTest.cs
+++ b/test/Data.UnitTests/Camera/CameraFactoryTest.cs
@@ -39,22 +39,22 @@ namespace Data.UnitTests.Camera
         private static ECamera CreateEntity() => new ()
         {
             Id = "0",
-            Latitude = "45.791795",
-            Longitude = "24.129404",
+            Latitude = 45.791795,
+            Longitude = 24.129404,
         };
 
         private static MRegisterCamera CreateInput() => new ()
         {
             Id = "0",
-            Latitude = "45.791795",
-            Longitude = "24.129404",
+            Latitude = 45.791795,
+            Longitude = 24.129404,
         };
 
         private static MCamera CreateModel() => new ()
         {
             Id = "0",
-            Latitude = "45.791795",
-            Longitude = "24.129404",
+            Latitude = 45.791795,
+            Longitude = 24.129404,
         };
     }
 }

--- a/test/Data.UnitTests/Detection/DetectionFactoryTests.cs
+++ b/test/Data.UnitTests/Detection/DetectionFactoryTests.cs
@@ -57,8 +57,8 @@ namespace Data.UnitTests.Detection
             Camera = new ECamera
             {
                 Id = "1",
-                Latitude = "1",
-                Longitude = "1",
+                Latitude = 1,
+                Longitude = 1,
             },
         };
 
@@ -78,8 +78,8 @@ namespace Data.UnitTests.Detection
             Camera = new MCamera
             {
                 Id = "1",
-                Latitude = "1",
-                Longitude = "1",
+                Latitude = 1,
+                Longitude = 1,
             },
         };
     }


### PR DESCRIPTION
## Description 
- We should change the longitude and latitude to be Double
- We change the types and models to match
- We should also add the migration for the entity

## Related 
[HER-130](https://nerds-interns.atlassian.net/jira/software/projects/HER/boards/1?selectedIssue=HER-130)